### PR TITLE
release(@archrad/deterministic): 0.4.2 — dedupe Compose init edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`archrad --version`** now reads the version from the shipped `package.json` (was hardcoded to `0.3.0` and drifted from the published tag).
 - `LoadPolicyPacksResult.ok` now includes a `signedBy` field (`'unsigned' | 'sha256-verified' | 'cosign-verified'`) so library callers can surface signing provenance in Cloud and CI summaries.
 
+## [0.4.2] - 2026-05-07
+
+**Theme:** Docker Compose `init` — one edge per service pair (no spurious duplicate-edge lint).
+
+### Fixed
+
+- **`archrad init --from` (Docker Compose):** When a service both **`depends_on`** another service and declares a connection URL (e.g. **`DATABASE_URL`**) to that same service, the importer now emits **one** edge per **`(from, to)`** — connection env is processed first, then **`depends_on`** skips an already-linked pair. Avoids **`IR-LINT-DUPLICATE-EDGE-006`** on typical Compose files.
+
+### Added
+
+- **Fixture** — `fixtures/docker-compose/demo-layered-two-bc.yml` for layered two–bounded-context smoke + lint tests.
+
 ## [0.4.1] - 2026-04-29
 
 **Theme:** MCP Registry — npm ownership marker + publisher manifest.

--- a/fixtures/docker-compose/demo-layered-two-bc.yml
+++ b/fixtures/docker-compose/demo-layered-two-bc.yml
@@ -1,0 +1,55 @@
+# Clean layered stack for `archrad init --from` + `archrad validate` (no IR-LINT-* warnings).
+#
+# - Single HTTP entry: `edge-gateway` (labels → auth + /health)
+# - No direct gateway→DB: domain services own DATABASE_URL only
+# - Graph depth from HTTP entry: gateway → service → DB (2 hops) — under IR-LINT-SYNC-CHAIN-001 threshold
+#
+# Add a BFF container between gateway and service if you want three tiers; expect IR-LINT-SYNC-CHAIN-001
+# unless you mark some edges async or shorten the sync path.
+
+services:
+  edge-gateway:
+    image: nginx:alpine
+    depends_on:
+      - client-service
+      - payments-service
+    ports:
+      - "8080:80"
+    labels:
+      archrad.auth: bearer
+      archrad.health_url: /health
+      archrad.http.method: GET
+
+  client-service:
+    image: archrad-demo/client-service:latest
+    environment:
+      DATABASE_URL: postgres://demo:demo@clients-db:5432/clients
+      NODE_ENV: production
+
+  clients-db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: demo
+      POSTGRES_PASSWORD: demo
+      POSTGRES_DB: clients
+    volumes:
+      - clients-data:/var/lib/postgresql/data
+
+  payments-service:
+    image: archrad-demo/payments-service:latest
+    environment:
+      DATABASE_URL: postgres://demo:demo@payments-db:5432/payments
+      NODE_ENV: production
+
+  payments-db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: demo
+      POSTGRES_PASSWORD: demo
+      POSTGRES_DB: payments
+    volumes:
+      - payments-data:/var/lib/postgresql/data
+
+volumes:
+  clients-data:
+  payments-data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@archrad/deterministic",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@archrad/deterministic",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archrad/deterministic",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "mcpName": "io.github.archradhq/deterministic",
   "description": "A deterministic compiler and linter for system architecture. Validate your architecture before you write code. OSS: structural validation + basic architecture lint (rule-based); FastAPI/Express export; OpenAPI document-shape; golden Docker/Makefile — no LLM.",
   "keywords": [

--- a/src/init/docker-compose.test.ts
+++ b/src/init/docker-compose.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { validateIrLint } from '../ir-lint.js';
 import { validateIrStructural, hasIrStructuralErrors } from '../ir-structural.js';
 import {
+  archradLintHintsFromLabels,
   connectionUrlHost,
   dockerComposeToCanonicalIr,
   inferTypeFromImage,
@@ -33,7 +34,7 @@ describe('connectionUrlHost', () => {
 });
 
 describe('dockerComposeToCanonicalIr', () => {
-  it('produces a graph with depends_on and DATABASE_URL edges', () => {
+  it('collapses depends_on and DATABASE_URL to one edge (same service pair)', () => {
     const yaml = `
 services:
   api:
@@ -47,18 +48,69 @@ services:
 `;
     const { ir, report } = dockerComposeToCanonicalIr(yaml);
     expect(report.services).toBe(2);
-    expect(report.edges).toBeGreaterThanOrEqual(2);
-    const g = ir.graph as { nodes: { id: string; type: string }[]; edges: unknown[] };
+    expect(report.edges).toBe(1);
+    const g = ir.graph as {
+      nodes: { id: string; type: string }[];
+      edges: { from: string; to: string; metadata?: Record<string, unknown> }[];
+    };
     const ids = new Set(g.nodes.map((n) => n.id));
     expect(ids.has('api')).toBe(true);
     expect(ids.has('postgres')).toBe(true);
     const api = g.nodes.find((n) => n.id === 'api');
     expect(api?.type).toBe('gateway');
-    expect(g.edges.length).toBeGreaterThanOrEqual(2);
+    expect(g.edges.length).toBe(1);
+    const e = g.edges[0];
+    expect(e.from).toBe('api');
+    expect(e.to).toBe('postgres');
+    expect(e.metadata?.relation).toBe('connectionUrl');
+    expect(e.metadata?.env).toBe('DATABASE_URL');
+  });
+
+  it('does not trigger IR-LINT-DUPLICATE-EDGE-006 when depends_on and DATABASE_URL share the same pair', () => {
+    const yaml = `
+services:
+  api:
+    image: mycompany/api:latest
+    depends_on: [postgres]
+    ports: ["8080:8080"]
+    environment:
+      DATABASE_URL: postgres://postgres:5432/db
+  postgres:
+    image: postgres:15
+`;
+    const { ir } = dockerComposeToCanonicalIr(yaml);
+    const lint = validateIrLint(ir);
+    const dup = lint.filter((f) => f.code === 'IR-LINT-DUPLICATE-EDGE-006');
+    expect(dup).toEqual([]);
   });
 
   it('rejects empty services', () => {
     expect(() => dockerComposeToCanonicalIr('services: {}')).toThrow(/No services found/);
+  });
+
+  it('archradLintHintsFromLabels maps documented compose labels to IR config', () => {
+    const hints = archradLintHintsFromLabels({
+      'archrad.auth': 'bearer',
+      'archrad.health_url': '/health',
+      'archrad.http.method': 'GET',
+    });
+    expect(hints.auth).toBe('bearer');
+    expect(hints.url).toBe('/health');
+    expect(hints.method).toBe('GET');
+    expect(archradLintHintsFromLabels({ 'archrad.auth_required': 'false' }).authRequired).toBe(false);
+  });
+
+  it('layered two-BC fixture passes architecture lint (no IR-LINT findings)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { dirname, join } = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+    const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const yaml = readFileSync(join(root, 'fixtures', 'docker-compose', 'demo-layered-two-bc.yml'), 'utf8');
+    const { ir } = dockerComposeToCanonicalIr(yaml);
+    const structural = validateIrStructural(ir);
+    expect(hasIrStructuralErrors(structural)).toBe(false);
+    const lint = validateIrLint(ir);
+    expect(lint.filter((f) => f.layer === 'lint')).toEqual([]);
   });
 
   it('demo fixture passes structural validation and triggers IR-LINT-DIRECT-DB-ACCESS-002', async () => {

--- a/src/init/docker-compose.ts
+++ b/src/init/docker-compose.ts
@@ -94,6 +94,64 @@ function parseEnvMap(serviceDef: Record<string, unknown>): Record<string, string
   return out;
 }
 
+function parseLabels(serviceDef: Record<string, unknown>): Record<string, string> {
+  const raw = serviceDef.labels;
+  if (raw == null) return {};
+  const out: Record<string, string> = {};
+  if (Array.isArray(raw)) {
+    for (const line of raw) {
+      if (typeof line !== 'string') continue;
+      const eq = line.indexOf('=');
+      if (eq === -1) continue;
+      out[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+    }
+    return out;
+  }
+  if (typeof raw === 'object' && !Array.isArray(raw)) {
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (v == null) continue;
+      out[String(k)] = typeof v === 'string' ? v : String(v);
+    }
+  }
+  return out;
+}
+
+function labelGet(labels: Record<string, string>, key: string): string | undefined {
+  if (labels[key] != null && String(labels[key]).trim() !== '') return String(labels[key]).trim();
+  const lower = key.toLowerCase();
+  for (const [k, v] of Object.entries(labels)) {
+    if (k.toLowerCase() === lower && String(v).trim() !== '') return String(v).trim();
+  }
+  return undefined;
+}
+
+/**
+ * Optional hints merged into each node's `config` for architecture lint after `archrad init --from` Compose.
+ * Convention (service `labels:`):
+ * - `archrad.auth` — e.g. `bearer` (satisfies IR-LINT-MISSING-AUTH-010 on HTTP entries)
+ * - `archrad.auth_required: "false"` — explicit public entry (same rule opt-out)
+ * - `archrad.health_url` or `archrad.health.url` — e.g. `/health` (helps IR-LINT-NO-HEALTHCHECK-003)
+ * - `archrad.http.method` — optional, e.g. `GET`
+ */
+export function archradLintHintsFromLabels(labels: Record<string, string>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const auth = labelGet(labels, 'archrad.auth');
+  if (auth !== undefined) out.auth = auth;
+
+  const pub = labelGet(labels, 'archrad.auth_required');
+  if (pub !== undefined && pub.toLowerCase() === 'false') out.authRequired = false;
+
+  const healthUrl = labelGet(labels, 'archrad.health_url') ?? labelGet(labels, 'archrad.health.url');
+  if (healthUrl !== undefined) {
+    out.url = healthUrl.startsWith('/') ? healthUrl : `/${healthUrl}`;
+  }
+
+  const method = labelGet(labels, 'archrad.http.method');
+  if (method !== undefined) out.method = method;
+
+  return out;
+}
+
 /** Extract hostname from common DB/cache/messaging URLs for cross-service edges. */
 export function connectionUrlHost(raw: string): string | null {
   const t = raw.trim();
@@ -206,12 +264,13 @@ export function dockerComposeToCanonicalIr(
   const verboseLines: string[] = [];
   const nodes: Record<string, unknown>[] = [];
   const edgeList: { from: string; to: string; reason: string }[] = [];
-  const seenEdge = new Set<string>();
+  /** One canonical edge per (from → to); duplicate IR edges trigger IR-LINT-DUPLICATE-EDGE-006. */
+  const linkedPair = new Set<string>();
 
   const pushEdge = (from: string, to: string, reason: string) => {
-    const key = `${from}\0${to}\0${reason}`;
-    if (seenEdge.has(key)) return;
-    seenEdge.add(key);
+    const pairKey = `${from}\0${to}`;
+    if (linkedPair.has(pairKey)) return;
+    linkedPair.add(pairKey);
     edgeList.push({ from, to, reason });
   };
 
@@ -241,11 +300,13 @@ export function dockerComposeToCanonicalIr(
           ? networks.map((x) => String(x))
           : Object.keys(networks as object);
 
+    const lintHints = archradLintHintsFromLabels(parseLabels(serviceDef));
     nodes.push({
       id,
       type: nodeType,
       name: serviceName,
       config: {
+        ...lintHints,
         compose: {
           image,
           ...(Object.keys(env).length ? { envKeys: Object.keys(env).sort() } : {}),
@@ -254,16 +315,8 @@ export function dockerComposeToCanonicalIr(
       },
     });
 
-    const deps = normalizeDependsOn(serviceDef.depends_on);
-    for (const depName of deps) {
-      const toId = idByServiceName.get(depName);
-      if (!toId) {
-        warnings.push(`depends_on: unknown service "${depName}" (from "${serviceName}")`);
-        continue;
-      }
-      pushEdge(id, toId, 'depends_on');
-    }
-
+    // Connection URLs first so `DATABASE_URL`→DB wins when `depends_on` also lists the same DB
+    // (Compose commonly sets both; they are one logical link in IR.)
     for (const key of CONNECTION_ENV_KEYS) {
       const val = env[key];
       if (!val) continue;
@@ -279,6 +332,16 @@ export function dockerComposeToCanonicalIr(
       }
       if (!targetId) continue;
       pushEdge(id, targetId, `${key}`);
+    }
+
+    const deps = normalizeDependsOn(serviceDef.depends_on);
+    for (const depName of deps) {
+      const toId = idByServiceName.get(depName);
+      if (!toId) {
+        warnings.push(`depends_on: unknown service "${depName}" (from "${serviceName}")`);
+        continue;
+      }
+      pushEdge(id, toId, 'depends_on');
     }
   }
 


### PR DESCRIPTION
Collapse depends_on + connection URL env into one edge per (from, to) so IR-LINT-DUPLICATE-EDGE-006 does not fire on typical docker-compose files. Add layered two-BC fixture and lint regression tests.